### PR TITLE
Support for SnackBar style notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.3] - 20202/3/13
+* expose toastTheme. by [juvs](https://github.com/juvs)
+
 ## [1.0.2] - 2019/10/23
 
 * fix Toast hidden behind ime #20

--- a/lib/overlay_support.dart
+++ b/lib/overlay_support.dart
@@ -4,6 +4,7 @@ export 'src/notification/overlay_notification.dart';
 export 'src/notification/notification.dart';
 export 'src/overlay.dart';
 export 'src/toast/toast.dart';
+export 'src/theme.dart';
 
 ///The length of time the notification is fully displayed
 Duration kNotificationDuration = const Duration(milliseconds: 2000);

--- a/lib/src/notification/notification.dart
+++ b/lib/src/notification/notification.dart
@@ -27,14 +27,16 @@ class BottomSlideNotification extends StatelessWidget {
   ///build notification content
   final WidgetBuilder builder;
 
-  final double progress;
+  final Animation<double> animation;
 
-  const BottomSlideNotification({Key key, @required this.builder, this.progress}) : super(key: key);
+  const BottomSlideNotification({Key key, @required this.builder, this.animation}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return FractionalTranslation(
-      translation: Offset.lerp(const Offset(0, 1), const Offset(0, 0), progress),
+    return SlideTransition(
+      position: Tween<Offset>(begin: const Offset(0, 1), end: const Offset(0, 0))
+          .chain(CurveTween(curve: Curves.ease))
+          .animate(animation),
       child: builder(context),
     );
   }

--- a/lib/src/notification/notification.dart
+++ b/lib/src/notification/notification.dart
@@ -22,7 +22,25 @@ class TopSlideNotification extends StatelessWidget {
   }
 }
 
-/// Can be dismiss by left or right slide.
+/// a notification show in front of screen and shown at the bottom
+class BottomSlideNotification extends StatelessWidget {
+  ///build notification content
+  final WidgetBuilder builder;
+
+  final double progress;
+
+  const BottomSlideNotification({Key key, @required this.builder, this.progress}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FractionalTranslation(
+      translation: Offset.lerp(const Offset(0, 1), const Offset(0, 0), progress),
+      child: builder(context),
+    );
+  }
+}
+
+/// Can be dismiss by left or right slide
 class SlideDismissible extends StatelessWidget {
   final Widget child;
 

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -9,18 +9,26 @@ import 'package:overlay_support/src/overlay.dart';
 ///if null , will be set to [kNotificationDuration]
 ///if zero , will not auto dismiss in the future
 ///
+/// [showAtBottom] show notification at the bottom of screen like a SnackBar
+///
 OverlaySupportEntry showOverlayNotification(
   WidgetBuilder builder, {
   Duration duration,
   Key key,
+  bool showAtBottom = false,
 }) {
   if (duration == null) {
     duration = kNotificationDuration;
   }
   return showOverlay((context, animation) {
+    MainAxisAlignment alignment = MainAxisAlignment.start;
+    if (showAtBottom) alignment = MainAxisAlignment.end;
     return Column(
+      mainAxisAlignment: alignment,
       children: <Widget>[
-        TopSlideNotification(builder: builder, animation: animation),
+        !showAtBottom
+            ? TopSlideNotification(builder: builder, animation: animation)
+            : BottomSlideNotification(builder: builder, animation: animation)
       ],
     );
   }, duration: duration, key: key);
@@ -42,6 +50,7 @@ OverlaySupportEntry showOverlayNotification(
 /// [elevation] the elevation of notification, see more [Material.elevation]
 /// [autoDismiss] true to auto hide after duration [kNotificationDuration]
 /// [slideDismiss] support left/right to dismiss notification
+/// [isSnackBar] support for SnackBar style notification, which displays at bottom of screen
 ///
 OverlaySupportEntry showSimpleNotification(Widget content,
     {Widget leading,
@@ -53,7 +62,8 @@ OverlaySupportEntry showSimpleNotification(Widget content,
     double elevation = 16,
     Key key,
     bool autoDismiss = true,
-    bool slideDismiss = false}) {
+    bool slideDismiss = false,
+    bool isSnackBar = false}) {
   final entry = showOverlayNotification((context) {
     return SlideDismissible(
       enable: slideDismiss,
@@ -76,6 +86,6 @@ OverlaySupportEntry showSimpleNotification(Widget content,
             )),
       ),
     );
-  }, duration: autoDismiss ? null : Duration.zero, key: key);
+  }, duration: autoDismiss ? null : Duration.zero, key: key, showAtBottom: isSnackBar);
   return entry;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: overlay_support
 description: proivder support for overlay, easy to build toast and internal notification
-version: 1.0.2
+version: 1.0.3
 author: YangBin <yangbinyhbn@gmail.com>
 homepage: https://github.com/boyan01/overlay_support
 


### PR DESCRIPTION
Hi, I've recently used this package to show a "No internet connection" message, and the use case was that the notification appear at the bottom of the screen like the [`SnackBar`](https://api.flutter.dev/flutter/material/SnackBar-class.html) widget. 

I saw that there's no customisability in this regard. So I've made a few very small changes to `showSimpleNotification `, `showOverlayNotification` and added a new `BottomSlideNotification` to allow for behaviour that mimics `SnackBar`, with all the other benefits of this package.

Improvements to my implementation can be made, for instance `BottomSlideNotification` only has a small difference to `TopSlideNotification` so they could be merged with an optional `position` parameter passed in. However, I didn't want to change the code too much so didn't implement this.

Let me know what you think and if this is something you would want to bring into the main branch.