### PR TITLE
Support for `BottomSlideNotification`

### DIFF
--- a/lib/src/notification/notification.dart
+++ b/lib/src/notification/notification.dart
@@ -62,3 +62,6 @@ class SlideDismissible extends StatelessWidget {
     );
   }
 }
+
+/// Indicates if notification is going to show at the [top] or at the [bottom].
+enum NotificationPosition { top, bottom }

--- a/lib/src/notification/notification.dart
+++ b/lib/src/notification/notification.dart
@@ -20,6 +20,23 @@ class TopSlideNotification extends StatelessWidget {
   }
 }
 
+class BottomSlideNotification extends StatelessWidget {
+  ///build notification content
+  final WidgetBuilder builder;
+
+  final double progress;
+
+  const BottomSlideNotification({Key key, @required this.builder, this.progress}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FractionalTranslation(
+      translation: Offset.lerp(const Offset(0, 1), const Offset(0, 0), progress),
+      child: builder(context),
+    );
+  }
+}
+
 ///can be dismiss by left or right slide
 class SlideDismissible extends StatelessWidget {
   final Widget child;

--- a/lib/src/notification/notification.dart
+++ b/lib/src/notification/notification.dart
@@ -20,6 +20,7 @@ class TopSlideNotification extends StatelessWidget {
   }
 }
 
+/// a notification show in front of screen and shown at the bottom
 class BottomSlideNotification extends StatelessWidget {
   ///build notification content
   final WidgetBuilder builder;

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -76,10 +76,8 @@ OverlaySupportEntry showSimpleNotification(Widget content,
         child: SafeArea(
             bottom: false,
             child: ListTileTheme(
-              textColor: foreground ??
-                  Theme.of(context)?.accentTextTheme?.title?.color,
-              iconColor: foreground ??
-                  Theme.of(context)?.accentTextTheme?.title?.color,
+              textColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,
+              iconColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,
               child: ListTile(
                 leading: leading,
                 title: content,
@@ -90,9 +88,6 @@ OverlaySupportEntry showSimpleNotification(Widget content,
             )),
       ),
     );
-  },
-      duration: autoDismiss ? null : Duration.zero,
-      key: key,
-      position: position);
+  }, duration: autoDismiss ? null : Duration.zero, key: key, position: position);
   return entry;
 }

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -74,7 +74,8 @@ OverlaySupportEntry showSimpleNotification(Widget content,
         color: background ?? Theme.of(context)?.accentColor,
         elevation: elevation,
         child: SafeArea(
-            bottom: false,
+            bottom: position == NotificationPosition.bottom,
+            top: position == NotificationPosition.top,
             child: ListTileTheme(
               textColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,
               iconColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -9,24 +9,24 @@ import 'package:overlay_support/src/overlay.dart';
 ///if null , will be set to [kNotificationDuration]
 ///if zero , will not auto dismiss in the future
 ///
-/// [showAtBottom] show notification at the bottom of screen like a SnackBar
+/// [position] the position of notification on the screen, default is [NotificationPosition.top]
 ///
 OverlaySupportEntry showOverlayNotification(
   WidgetBuilder builder, {
   Duration duration,
   Key key,
-  bool showAtBottom = false,
+  NotificationPosition position = NotificationPosition.top,
 }) {
   if (duration == null) {
     duration = kNotificationDuration;
   }
   return showOverlay((context, t) {
     MainAxisAlignment alignment = MainAxisAlignment.start;
-    if (showAtBottom) alignment = MainAxisAlignment.end;
+    if (position == NotificationPosition.bottom) alignment = MainAxisAlignment.end;
     return Column(
       mainAxisAlignment: alignment,
       children: <Widget>[
-        !showAtBottom
+        position == NotificationPosition.top
             ? TopSlideNotification(builder: builder, progress: t)
             : BottomSlideNotification(builder: builder, progress: t)
       ],
@@ -50,7 +50,7 @@ OverlaySupportEntry showOverlayNotification(
 /// [elevation] the elevation of notification, see more [Material.elevation]
 /// [autoDismiss] true to auto hide after duration [kNotificationDuration]
 /// [slideDismiss] support left/right to dismiss notification
-/// [isSnackBar] support for SnackBar style notification, which displays at bottom of screen
+/// [position] the position of notification, can be [NotificationPosition.top] or [NotificationPosition.bottom], default is [NotificationPosition.top]
 ///
 OverlaySupportEntry showSimpleNotification(Widget content,
     {Widget leading,
@@ -63,7 +63,7 @@ OverlaySupportEntry showSimpleNotification(Widget content,
     Key key,
     bool autoDismiss = true,
     bool slideDismiss = false,
-    bool isSnackBar = false}) {
+    NotificationPosition position = NotificationPosition.top}) {
   final entry = showOverlayNotification((context) {
     return SlideDismissible(
       enable: slideDismiss,
@@ -74,8 +74,10 @@ OverlaySupportEntry showSimpleNotification(Widget content,
         child: SafeArea(
             bottom: false,
             child: ListTileTheme(
-              textColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,
-              iconColor: foreground ?? Theme.of(context)?.accentTextTheme?.title?.color,
+              textColor: foreground ??
+                  Theme.of(context)?.accentTextTheme?.title?.color,
+              iconColor: foreground ??
+                  Theme.of(context)?.accentTextTheme?.title?.color,
               child: ListTile(
                 leading: leading,
                 title: content,
@@ -86,6 +88,9 @@ OverlaySupportEntry showSimpleNotification(Widget content,
             )),
       ),
     );
-  }, duration: autoDismiss ? null : Duration.zero, key: key, showAtBottom: isSnackBar);
+  },
+      duration: autoDismiss ? null : Duration.zero,
+      key: key,
+      position: position);
   return entry;
 }

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -48,6 +48,7 @@ OverlaySupportEntry showOverlayNotification(
 /// [elevation] the elevation of notification, see more [Material.elevation]
 /// [autoDismiss] true to auto hide after duration [kNotificationDuration]
 /// [slideDismiss] support left/right to dismiss notification
+/// [isSnackBar] support for SnackBar style notification, which displays at bottom of screen
 ///
 OverlaySupportEntry showSimpleNotification(Widget content,
     {Widget leading,

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -9,7 +9,8 @@ import 'package:overlay_support/src/overlay.dart';
 ///if null , will be set to [kNotificationDuration]
 ///if zero , will not auto dismiss in the future
 ///
-/// [position] the position of notification on the screen, default is [NotificationPosition.top]
+/// [position] the position of notification, default is [NotificationPosition.top],
+/// can be [NotificationPosition.top] or [NotificationPosition.bottom]
 ///
 OverlaySupportEntry showOverlayNotification(
   WidgetBuilder builder, {
@@ -50,7 +51,8 @@ OverlaySupportEntry showOverlayNotification(
 /// [elevation] the elevation of notification, see more [Material.elevation]
 /// [autoDismiss] true to auto hide after duration [kNotificationDuration]
 /// [slideDismiss] support left/right to dismiss notification
-/// [position] the position of notification, can be [NotificationPosition.top] or [NotificationPosition.bottom], default is [NotificationPosition.top]
+/// [position] the position of notification, default is [NotificationPosition.top],
+/// can be [NotificationPosition.top] or [NotificationPosition.bottom]
 ///
 OverlaySupportEntry showSimpleNotification(Widget content,
     {Widget leading,

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -9,6 +9,8 @@ import 'package:overlay_support/src/overlay.dart';
 ///if null , will be set to [kNotificationDuration]
 ///if zero , will not auto dismiss in the future
 ///
+/// [showAtBottom] show notification at the bottom of screen like a SnackBar
+///
 OverlaySupportEntry showOverlayNotification(
   WidgetBuilder builder, {
   Duration duration,

--- a/lib/src/notification/overlay_notification.dart
+++ b/lib/src/notification/overlay_notification.dart
@@ -13,14 +13,20 @@ OverlaySupportEntry showOverlayNotification(
   WidgetBuilder builder, {
   Duration duration,
   Key key,
+  bool showAtBottom = false,
 }) {
   if (duration == null) {
     duration = kNotificationDuration;
   }
   return showOverlay((context, t) {
+    MainAxisAlignment alignment = MainAxisAlignment.start;
+    if (showAtBottom) alignment = MainAxisAlignment.end;
     return Column(
+      mainAxisAlignment: alignment,
       children: <Widget>[
-        TopSlideNotification(builder: builder, progress: t),
+        !showAtBottom
+            ? TopSlideNotification(builder: builder, progress: t)
+            : BottomSlideNotification(builder: builder, progress: t)
       ],
     );
   }, duration: duration, key: key);
@@ -53,7 +59,8 @@ OverlaySupportEntry showSimpleNotification(Widget content,
     double elevation = 16,
     Key key,
     bool autoDismiss = true,
-    bool slideDismiss = false}) {
+    bool slideDismiss = false,
+    bool isSnackBar = false}) {
   final entry = showOverlayNotification((context) {
     return SlideDismissible(
       enable: slideDismiss,
@@ -76,6 +83,6 @@ OverlaySupportEntry showSimpleNotification(Widget content,
             )),
       ),
     );
-  }, duration: autoDismiss ? null : Duration.zero, key: key);
+  }, duration: autoDismiss ? null : Duration.zero, key: key, showAtBottom: isSnackBar);
   return entry;
 }


### PR DESCRIPTION
Hi, 

This PR covers the new implementation of #39 which removes references to `SnackBar` and updates implementation to use `position` which can be `NotificationPosition.top` or `NotificationPosition.bottom`.