### PR TITLE
Removed no longer existing parameter from toast method

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -24,7 +24,7 @@ showOverlayNotification((context) {
     message: 'i love you',
     onReplay: () {
       OverlaySupportEntry.of(context).dismiss(); //use OverlaySupportEntry to dismiss overlay
-      toast(context, 'you checked this message');
+      toast('you checked this message');
     },
   );
 ```


### PR DESCRIPTION
Removed context parameter from toast method call in showOverlayNotification example.